### PR TITLE
Add support for Android arm64

### DIFF
--- a/src/esgleam/mod/platform.gleam
+++ b/src/esgleam/mod/platform.gleam
@@ -2,6 +2,7 @@
 
 pub type OsName {
   Win32
+  Android
   Linux
   Darwin
   Solaris
@@ -32,6 +33,7 @@ pub fn get_package_name() {
 
   let os_str = case os {
     Win32 -> "win32"
+    Android -> "android"
     Linux -> "linux"
     Darwin -> "darwin"
     Solaris | Sunos -> "sunos"

--- a/src/ffi_esgleam.mjs
+++ b/src/ffi_esgleam.mjs
@@ -6,6 +6,7 @@ import { resolve } from 'node:path';
 import { Buffer } from 'node:buffer';
 import { default as process } from 'node:process';
 import {
+  Android,
   Win32,
   Linux,
   Darwin,
@@ -34,6 +35,7 @@ export function exec_shell(command) {
 
 /** @type {Partial<Record<NodeJS.Platform, () => import('../build/dev/javascript/esgleam/esgleam/mod/platform.d.mts').OsName$>>} */
 const platform_map = {
+  android: () => new Android(),
   darwin: () => new Darwin(),
   freebsd: () => new Freebsd(),
   linux: () => new Linux(),


### PR DESCRIPTION
This enables download of the android arm64 prebuilt binary of esbuild.

Works for me under Termux on my android device.